### PR TITLE
Add compiler errorformat for `bats --tap` output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # vim-bats
 
-This plugin adds a `:Bats` command that runs [bats][bats]. It also sets up
-syntax highlighting for files with a .bats extension using the ftdetect
-plugin from [bats.vim][bats.vim].
+This plugin adds:
+
+* A `:Bats` command that runs [bats][bats]
+* Syntax highlighting for files with a .bats extension using the ftdetect plugin from [bats.vim][bats.vim]
+* A `bats` compiler errorformat, which can parse output from `bats --tap` for display line numbers and errors in a quickfix window
 
 ## Installation
 

--- a/compiler/bats.vim
+++ b/compiler/bats.vim
@@ -1,0 +1,12 @@
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = 'bats'
+
+let s:errorformat = join([
+  \ '%Enot ok %. %m',
+  \ '%-C# (in test file %f\\, line %l)',
+  \ '%+C# %m',
+  \ '%-G%.%#'
+  \ ], ',')
+execute 'CompilerSet errorformat=' . escape(s:errorformat, ' ')


### PR DESCRIPTION
``` viml
compiler bats
set makeprg=bats\ --tap\ %
```

Using https://github.com/justincampbell/use/blob/master/test/cli_test.bats as an example and changing the expected exit codes:

![screenshot](http://f.cl.ly/items/021Z2i0a2a2V2A3c0r0g/Screen%20Shot%202014-06-04%20at%2010.00.29%20AM.png)
