### PR TITLE
ftdetect: Set shell type to bash

### DIFF
--- a/ftdetect/bats.vim
+++ b/ftdetect/bats.vim
@@ -1,1 +1,2 @@
 au BufRead,BufNewFile *.bats set filetype=sh
+au BufRead,BufNewFile *.bats let g:is_bash=1


### PR DESCRIPTION
sh.vim / ft-bash-syntax doesn't autodetect `*.bats` files, so help it out.